### PR TITLE
Update license

### DIFF
--- a/AdafruitClassLibrary/BNO055.cs
+++ b/AdafruitClassLibrary/BNO055.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/CharLCDPlate.cs
+++ b/AdafruitClassLibrary/CharLCDPlate.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit CharLCDPlate is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/DotStar.cs
+++ b/AdafruitClassLibrary/DotStar.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/GPS.cs
+++ b/AdafruitClassLibrary/GPS.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/I2CBase.cs
+++ b/AdafruitClassLibrary/I2CBase.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/MCP23017.cs
+++ b/AdafruitClassLibrary/MCP23017.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/AdafruitClassLibrary/MotorHat.cs
+++ b/AdafruitClassLibrary/MotorHat.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System.Collections.Generic;

--- a/AdafruitClassLibrary/PCA9685.cs
+++ b/AdafruitClassLibrary/PCA9685.cs
@@ -7,14 +7,6 @@
   please support Adafruit and open-source hardware by purchasing products
   from Adafruit!
 
-  ------------------------------------------------------------------------
-  This file is part of the Adafruit Windows IoT Class Library
-
-  Adafruit Class Library is distributed in the hope that it will be useful,
-  but WITHOUT ANY WARRANTY; without even the implied warranty of
-  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-
-  MIT license, all text above must be included in any redistribution.
   ------------------------------------------------------------------------*/
 
 using System;

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2016 Adafruit Industries, LLC
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
This PR is a fix for issue #14.

I added the LICENSE.txt file which contains the text of the MIT license, and naming "Adafruit Industries, LLC" as the copyright holder. I used 2016 as the copyright year, as this is when the repository was created.

I removed the ambiguous license text from all source code file headers. I did not put the text of the MIT license within the source code files, as the MIT license does not require or even suggest that this be done. However, I will be glad to add it as part of the file header, if requested.

With the above paragraph in mind, I **did** leave the other part of the file header which includes the following:
- the package name (Adafruit Class Library for Windows Core IoT)
- the file's purpose
- the original author's name
- a notice/request that the reader supports Adafruit & open source hardware by purchasing products from Adafruit, in return for providing the source code

One other note, it would be nice to have the license on [the package's Nuget Gallery page](https://www.nuget.org/packages/AdafruitClassLibrary/) to link to the LICENSE.txt page that will be created for this project, in the master branch, after this PR is merged.